### PR TITLE
Refactor the logic around handling public tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ When a federated services creates a new token (when non exist) it can also
 return a refresh token in the `x-refresh-token` header. The gateway will then
 encrypt all refresh tokens and encrypt them before passing them to the client
 as `x-refresh-token` header.
+
+
+# Token sources
+
+
+## Cookie Token Source
+This token source is used for browser clients to safely store the token. It is
+implemented via 4 cookies:
+ - accessToken - The JWT token
+ - tokenFingerprint - A random string that is used to protect the AccessToken
+   cookie from CSRF attacks. It is stored as HTTP_ONLY cookie.
+ - refreshToken - The refresh token, if any. It is stored as HTTP_ONLY cookie.
+ - refreshTokenExists - A boolean value that indicates if a refresh token exists
+   for the user. It is used to determine if the user is new or not.

--- a/package.json
+++ b/package.json
@@ -43,12 +43,15 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.26.2",
 		"@sentry/types": "7.55.0",
+		"@types/cookie-parser": "^1.4.3",
 		"@types/crypto-js": "4.1.1",
+		"@types/express": "^4.17.17",
 		"@types/lodash-es": "4.17.7",
 		"@typescript-eslint/eslint-plugin": "^5.60.1",
 		"@vitest/coverage-v8": "0.32.2",
 		"eslint": "^8.40.0",
 		"eslint-plugin-unused-imports": "^2.0.0",
+		"node-mocks-http": "^1.12.2",
 		"tsup": "^7.1.0",
 		"typescript": "^5.1.5",
 		"vitest": "0.32.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,15 @@ devDependencies:
   '@sentry/types':
     specifier: 7.55.0
     version: 7.55.0
+  '@types/cookie-parser':
+    specifier: ^1.4.3
+    version: 1.4.3
   '@types/crypto-js':
     specifier: 4.1.1
     version: 4.1.1
+  '@types/express':
+    specifier: ^4.17.17
+    version: 4.17.17
   '@types/lodash-es':
     specifier: 4.17.7
     version: 4.17.7
@@ -51,6 +57,9 @@ devDependencies:
   eslint-plugin-unused-imports:
     specifier: ^2.0.0
     version: 2.0.0(@typescript-eslint/eslint-plugin@5.60.1)(eslint@8.40.0)
+  node-mocks-http:
+    specifier: ^1.12.2
+    version: 1.12.2
   tsup:
     specifier: ^7.1.0
     version: 7.1.0(typescript@5.1.5)
@@ -1231,7 +1240,6 @@ packages:
     dependencies:
       '@types/connect': 3.4.35
       '@types/node': 20.3.1
-    dev: false
 
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
@@ -1247,7 +1255,12 @@ packages:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
       '@types/node': 20.3.1
-    dev: false
+
+  /@types/cookie-parser@1.4.3:
+    resolution: {integrity: sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==}
+    dependencies:
+      '@types/express': 4.17.17
+    dev: true
 
   /@types/crypto-js@4.1.1:
     resolution: {integrity: sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==}
@@ -1260,7 +1273,6 @@ packages:
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
-    dev: false
 
   /@types/express@4.17.17:
     resolution: {integrity: sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==}
@@ -1269,11 +1281,9 @@ packages:
       '@types/express-serve-static-core': 4.17.35
       '@types/qs': 6.9.7
       '@types/serve-static': 1.15.2
-    dev: false
 
   /@types/http-errors@2.0.1:
     resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
-    dev: false
 
   /@types/is-ci@3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
@@ -1305,11 +1315,9 @@ packages:
 
   /@types/mime@1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
-    dev: false
 
   /@types/mime@3.0.1:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
-    dev: false
 
   /@types/minimist@1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
@@ -1335,11 +1343,9 @@ packages:
 
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
-    dev: false
 
   /@types/range-parser@1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
-    dev: false
 
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
@@ -1350,7 +1356,6 @@ packages:
     dependencies:
       '@types/mime': 1.3.2
       '@types/node': 20.3.1
-    dev: false
 
   /@types/serve-static@1.15.2:
     resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==}
@@ -1358,7 +1363,6 @@ packages:
       '@types/http-errors': 2.0.1
       '@types/mime': 3.0.1
       '@types/node': 20.3.1
-    dev: false
 
   /@types/uuid@9.0.2:
     resolution: {integrity: sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==}
@@ -1560,7 +1564,6 @@ packages:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
-    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.9.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2015,7 +2018,6 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       safe-buffer: 5.2.1
-    dev: false
 
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -2178,6 +2180,11 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
     dev: false
+
+  /depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+    dev: true
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2748,7 +2755,6 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -3565,7 +3571,6 @@ packages:
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /meow@6.1.1:
     resolution: {integrity: sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==}
@@ -3586,7 +3591,6 @@ packages:
 
   /merge-descriptors@1.0.1:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
-    dev: false
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3600,7 +3604,6 @@ packages:
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -3613,20 +3616,17 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: false
 
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: false
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -3775,7 +3775,6 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
@@ -3792,6 +3791,22 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
     dev: false
+
+  /node-mocks-http@1.12.2:
+    resolution: {integrity: sha512-xhWwC0dh35R9rf0j3bRZXuISXdHxxtMx0ywZQBwjrg3yl7KpRETzogfeCamUIjltpn0Fxvs/ZhGJul1vPLrdJQ==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      accepts: 1.3.8
+      content-disposition: 0.5.4
+      depd: 1.1.2
+      fresh: 0.5.2
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      mime: 1.6.0
+      parseurl: 1.3.3
+      range-parser: 1.2.1
+      type-is: 1.6.18
+    dev: true
 
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -3962,7 +3977,6 @@ packages:
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-    dev: false
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -4149,7 +4163,6 @@ packages:
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /raw-body@2.5.1:
     resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
@@ -4301,7 +4314,6 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -4878,7 +4890,6 @@ packages:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-    dev: false
 
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -62,7 +62,7 @@ export class FederatedGraphQLDataSource extends RemoteGraphQLDataSource<PublicFe
 			if (!context.federatedToken) {
 				context.federatedToken = new PublicFederatedToken();
 			}
-			context.federatedToken.loadRefreshToken(refreshToken);
+			context.federatedToken.loadRefreshToken(refreshToken, true);
 		}
 		return response;
 	}

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -1,0 +1,19 @@
+import { randomBytes } from "crypto";
+import { createHash } from "node:crypto";
+
+export const generateFingerprint = (): string => {
+  const length = 32;
+  const buffer = randomBytes(Math.ceil(length / 2));
+  return buffer.toString("hex").slice(0, length);
+};
+
+export const hashFingerprint = (fingerprint: string): string => {
+  const hash = createHash("sha256");
+  hash.update(fingerprint);
+  return hash.digest("hex");
+};
+
+export const validateFingerprint = (
+  fingerprint: string,
+  hashedFingerprint: string
+) => hashFingerprint(fingerprint) === hashedFingerprint;

--- a/src/gateway.test.ts
+++ b/src/gateway.test.ts
@@ -1,4 +1,4 @@
-import { ApolloServer, GraphQLRequestMetrics, HeaderMap } from "@apollo/server";
+import { ApolloServer, HeaderMap } from "@apollo/server";
 import { GatewayAuthPlugin } from "./gateway";
 import {
 	PublicFederatedToken,
@@ -6,6 +6,8 @@ import {
 	TokenSigner,
 } from "./jwt";
 import { assert, describe, expect, it } from "vitest";
+import httpMocks from "node-mocks-http";
+import { HeaderTokenSource } from "./tokensource";
 
 describe("GatewayAuthPlugin", () => {
 	const signer = new TokenSigner({
@@ -14,13 +16,17 @@ describe("GatewayAuthPlugin", () => {
 		encryptKey: "foo",
 		signKey: "bar",
 	});
-	const plugin = new GatewayAuthPlugin(signer);
+
+	const plugin = new GatewayAuthPlugin({
+		signer: signer,
+		source: new HeaderTokenSource(),
+	});
 
 	const typeDefs = `#graphql
  			type Query {
-    		testToken(create: Boolean): String!
-    		refreshToken: String!
-  		}
+				testToken(create: Boolean): String!
+				refreshToken: String!
+			}
 	`;
 	const resolvers = {
 		Query: {
@@ -29,19 +35,19 @@ describe("GatewayAuthPlugin", () => {
 				{ create }: { create: boolean },
 				context: PublicFederatedTokenContext
 			) => {
+				if (!context.federatedToken) {
+					throw new Error("No federated token");
+				}
 				if (create) {
-					context.federatedToken?.setAccessToken("foo", {
+					context.federatedToken.setAccessToken("foo", {
 						token: "bar",
 						exp: Date.now() + 1000,
 					});
-					context.federatedToken?.setRefreshToken("foo", "bar");
+					context.federatedToken.setRefreshToken("foo", "bar");
 				}
 				return JSON.stringify(context.federatedToken);
 			},
-			refreshToken: (
-				_: any,
-				context: PublicFederatedTokenContext
-			) => {
+			refreshToken: (_: any, context: PublicFederatedTokenContext) => {
 				context.federatedToken?.setAccessToken("foo", {
 					token: "bar",
 					exp: Date.now() + 1000,
@@ -58,66 +64,88 @@ describe("GatewayAuthPlugin", () => {
 	});
 
 	it("should return the plugin instance", async () => {
-		const headers = new HeaderMap();
 		const context = {
 			federatedToken: new PublicFederatedToken(),
+			res: httpMocks.createResponse(),
+			req: httpMocks.createRequest(),
 		};
-		const response = await testServer.executeOperation(
+		await testServer.executeOperation(
 			{
 				query: "query testToken { testToken(create: true) }",
-				http: { headers: headers, method: "POST", search: "", body: "" },
+				http: {
+					headers: new HeaderMap(),
+					method: "POST",
+					search: "",
+					body: "",
+				},
 			},
 			{
 				contextValue: context,
 			}
 		);
-		assert.exists(response.http.headers.get("x-access-token"));
-		assert.exists(response.http.headers.get("x-refresh-token"));
+		expect(context.res.statusCode).toBe(200);
+		expect(context.res.get("x-access-token")).toBeDefined();
+		expect(context.res.get("x-refresh-token")).toBeDefined();
 	});
 
 	it("Use generated token", async () => {
-		let headers = new HeaderMap();
 		let context = {
 			federatedToken: new PublicFederatedToken(),
+			res: httpMocks.createResponse(),
+			req: httpMocks.createRequest(),
 		};
-		let response = await testServer.executeOperation(
+		await testServer.executeOperation(
 			{
 				query: "query testToken { testToken(create: true) }",
-				http: { headers: headers, method: "POST", search: "", body: "" },
+				http: {
+					headers: new HeaderMap(),
+					method: "POST",
+					search: "",
+					body: "",
+				},
 			},
 			{
 				contextValue: context,
 			}
 		);
-		assert.exists(response.http.headers.get("x-access-token"));
-		assert.exists(response.http.headers.get("x-refresh-token"));
+		expect(context.res.statusCode).toBe(200);
+		expect(context.res.get("x-access-token")).toBeDefined();
+		expect(context.res.get("x-refresh-token")).toBeDefined();
+		const accessToken = context.res.get("x-access-token");
 
 		// Set received token
-		headers = new HeaderMap();
-		headers.set(
-			"Authorization",
-			"Bearer " + response.http.headers.get("x-access-token")
-		);
-		context = {
+		const newContext = {
 			federatedToken: new PublicFederatedToken(),
+			res: httpMocks.createResponse(),
+			req: httpMocks.createRequest({
+				headers: {
+					"x-access-token": `Bearer ${accessToken}`,
+				},
+			}),
 		};
-		response = await testServer.executeOperation(
+		const response = await testServer.executeOperation(
 			{
 				query: "query testToken { testToken(create: false) }",
-				http: { headers: headers, method: "POST", search: "", body: "" },
+				http: {
+					headers: new HeaderMap(),
+					method: "POST",
+					search: "",
+					body: "",
+				},
 			},
 			{
-				contextValue: context,
+				contextValue: newContext,
 			}
 		);
-		assert.equal(response.body.kind, "single");
-		assert(response.body.kind === "single");
+		expect(response.body.kind).toBe("single");
+		assert(response.body.kind === "single"); // Make typescript happy
+		expect(response.body.singleResult).toBeDefined();
 
 		const token = JSON.parse(
 			response.body.singleResult.data?.testToken as string
 		) as PublicFederatedToken;
 		expect(token.tokens.foo.token).toBe("bar");
-		expect(response.http.headers.get("x-access-token")).toBeUndefined();
-		expect(response.http.headers.get("x-refresh-token")).toBeUndefined();
+		expect(newContext.res.get("x-access-token")).toBeUndefined();
+		expect(newContext.res.get("x-refresh-token")).toBeUndefined();
 	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,9 @@ export { PublicFederatedToken, TokenSigner } from "./jwt";
 export { FederatedAuthPlugin } from "./plugin";
 export { FederatedToken } from "./token";
 
+export { type TokenSource } from "./tokensource";
+export {
+  CompositeTokenSource,
+  CookieTokenSource,
+  HeaderTokenSource,
+} from "./tokensource";

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -1,168 +1,216 @@
 import CryptoJS from "crypto-js";
 import * as jose from "jose";
 import { FederatedToken } from "./token";
+import { Response, Request } from "express";
+import {
+  generateFingerprint,
+  hashFingerprint,
+  validateFingerprint,
+} from "./fingerprint";
 
 export type PublicFederatedTokenContext = {
-	federatedToken?: PublicFederatedToken;
+  federatedToken?: PublicFederatedToken;
+  res: Response;
+  req: Request;
 };
 
 type TokenSignerOptions = {
-	encryptKey: string;
-	signKey: string;
-	audience: string;
-	issuer: string;
+  encryptKey: string;
+  signKey: string;
+  audience: string;
+  issuer: string;
+};
+
+type JWTPayload = {
+  exp: number;
+  state: string;
+  _fingerprint: string;
+  [key: string]: any;
 };
 
 const padUint8Array = (
-	array: Uint8Array,
-	desiredLength: number
+  array: Uint8Array,
+  desiredLength: number
 ): Uint8Array => {
-	if (array.length >= desiredLength) {
-		return array;
-	}
+  if (array.length >= desiredLength) {
+    return array;
+  }
 
-	const paddedArray = new Uint8Array(desiredLength);
-	paddedArray.set(array, desiredLength - array.length);
-	return paddedArray;
+  const paddedArray = new Uint8Array(desiredLength);
+  paddedArray.set(array, desiredLength - array.length);
+  return paddedArray;
 };
 
+export class TokenExpiredError extends Error {}
+
+export class ConfigurationError extends Error {}
+
+export class TokenInvalidError extends Error {}
+
 export class TokenSigner {
-	private _encryptKey: Uint8Array;
-	private _signKey: Uint8Array;
+  private _encryptKey: Uint8Array;
+  private _signKey: Uint8Array;
 
-	constructor(private config: TokenSignerOptions) {
-		if (!config.encryptKey) {
-			throw new Error("Missing encryptKey");
-		}
-		if (!config.signKey) {
-			throw new Error("Missing signKey");
-		}
-		if (!config.audience) {
-			throw new Error("Missing audience");
-		}
-		if (!config.issuer) {
-			throw new Error("Missing issuer");
-		}
+  constructor(private config: TokenSignerOptions) {
+    if (!config.encryptKey) {
+      throw new ConfigurationError("Missing encryptKey");
+    }
+    if (!config.signKey) {
+      throw new ConfigurationError("Missing signKey");
+    }
+    if (!config.audience) {
+      throw new ConfigurationError("Missing audience");
+    }
+    if (!config.issuer) {
+      throw new ConfigurationError("Missing issuer");
+    }
 
-		this._encryptKey = padUint8Array(
-			jose.base64url.decode(config.encryptKey),
-			32
-		);
-		if (this._encryptKey.length != 32) {
-			throw new Error("Invalid encryptKey length");
-		}
-		this._signKey = jose.base64url.decode(config.signKey);
-	}
+    this._encryptKey = padUint8Array(
+      jose.base64url.decode(config.encryptKey),
+      32
+    );
+    if (this._encryptKey.length != 32) {
+      throw new Error("Invalid encryptKey length");
+    }
+    this._signKey = jose.base64url.decode(config.signKey);
+  }
 
-	encryptString(value: string) {
-		const key = jose.base64url.encode(this._encryptKey);
-		return CryptoJS.AES.encrypt(value, key).toString();
-	}
+  encryptString(value: string) {
+    const key = jose.base64url.encode(this._encryptKey);
+    return CryptoJS.AES.encrypt(value, key).toString();
+  }
 
-	decryptString(value: string) {
-		const key = jose.base64url.encode(this._encryptKey);
-		return CryptoJS.AES.decrypt(value, key).toString(CryptoJS.enc.Utf8);
-	}
+  decryptString(value: string) {
+    const key = jose.base64url.encode(this._encryptKey);
+    return CryptoJS.AES.decrypt(value, key).toString(CryptoJS.enc.Utf8);
+  }
 
-	async signJWT(payload: any, exp: number) {
-		return await new jose.SignJWT(payload)
-			.setExpirationTime(exp)
-			.setIssuedAt()
-			.setProtectedHeader({ alg: "HS256" })
-			.setAudience(this.config.audience)
-			.setIssuer(this.config.issuer)
-			.sign(this._signKey);
-	}
+  async signJWT(payload: any, exp: number) {
+    return await new jose.SignJWT(payload)
+      .setExpirationTime(exp)
+      .setIssuedAt()
+      .setProtectedHeader({ alg: "HS256" })
+      .setAudience(this.config.audience)
+      .setIssuer(this.config.issuer)
+      .sign(this._signKey);
+  }
 
-	async verifyJWT(value: string) {
-		return await jose.jwtVerify(value, this._signKey, {
-			algorithms: ["HS256"],
-			audience: this.config.audience,
-			issuer: this.config.issuer,
-		});
-	}
+  async verifyJWT(value: string) {
+    return await jose.jwtVerify(value, this._signKey, {
+      algorithms: ["HS256"],
+      audience: this.config.audience,
+      issuer: this.config.issuer,
+    });
+  }
 
-	// For refresh token
-	async encryptJWT(payload: any, exp: number) {
-		const data = await new jose.EncryptJWT(payload)
-			.setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256" })
-			.setIssuedAt()
-			.setIssuer(this.config.issuer)
-			.setAudience(this.config.audience)
-			.setExpirationTime(exp)
-			.encrypt(this._encryptKey);
-		return data;
-	}
+  // For refresh token
+  async encryptJWT(payload: any, exp: number) {
+    const data = await new jose.EncryptJWT(payload)
+      .setProtectedHeader({ alg: "dir", enc: "A128CBC-HS256" })
+      .setIssuedAt()
+      .setIssuer(this.config.issuer)
+      .setAudience(this.config.audience)
+      .setExpirationTime(exp)
+      .encrypt(this._encryptKey);
+    return data;
+  }
 
-	async decryptJWT(jwt: string) {
-		return await jose.jwtDecrypt(jwt, this._encryptKey, {
-			audience: this.config.audience,
-			issuer: this.config.issuer,
-		});
-	}
+  async decryptJWT(jwt: string) {
+    return await jose.jwtDecrypt(jwt, this._encryptKey, {
+      audience: this.config.audience,
+      issuer: this.config.issuer,
+    });
+  }
 }
 
 export class PublicFederatedToken extends FederatedToken {
-	async createAccessJWT(signer: TokenSigner) {
-		// Find the expire time of the first token that expires
-		const values = Object.values(this.tokens);
-		const sorted = values.sort((a, b) => a.exp - b.exp);
-		const exp = sorted[0].exp;
+  async createAccessJWT(signer: TokenSigner) {
+    // Find the expire time of the first token that expires
+    const values = Object.values(this.tokens);
+    const sorted = values.sort((a, b) => a.exp - b.exp);
+    const exp = sorted[0].exp;
 
-		const payload = {
-			exp: exp,
-			state: this.encryptTokens(signer),
-			...this.values,
-		};
+    const fingerprint = generateFingerprint();
+    const payload: JWTPayload = {
+      exp: exp,
+      state: this.encryptTokens(signer),
+      ...this.values,
+      _fingerprint: hashFingerprint(fingerprint),
+    };
 
-		return signer.signJWT(payload, exp);
-	}
+    const token = await signer.signJWT(payload, exp);
 
-	async loadAccessJWT(signer: TokenSigner, value: string) {
-		const result = await signer.verifyJWT(value);
-		if (!result) {
-			throw new Error("Invalid JWT");
-		}
+    return {
+      accessToken: token,
+      fingerprint: fingerprint,
+    };
+  }
 
-		const payload = result.payload;
-		this.tokens = this.decryptTokens(signer, payload.state as string);
-		const knownKeys = ["state", "iat", "exp", "aud", "iss"];
-		for (const k in payload) {
-			if (!knownKeys.includes(k)) {
-				this.values[k] = payload[k];
-			}
-		}
-	}
+  async loadAccessJWT(
+    signer: TokenSigner,
+    value: string,
+    fingerprint?: string
+  ) {
+    const result = await signer.verifyJWT(value);
+    if (!result) {
+      throw new Error("Invalid JWT");
+    }
 
-	async createRefreshJWT(signer: TokenSigner) {
-		// Find the expire time of the first token that expires
-		const payload = this.refreshTokens;
-		const exp = Date.now() + 1000 * 60 * 60 * 24 * 90; // 30 days
-		return signer.encryptJWT(payload, exp);
-	}
+    const payload = result.payload as JWTPayload
+    if (!payload) {
+      throw new TokenInvalidError("Invalid JWT");
+    }
 
-	async loadRefreshJWT(signer: TokenSigner, value: string) {
-		const result = await signer.decryptJWT(value);
-		if (!result) {
-			throw new Error("Invalid JWT");
-		}
+    // The expire time should be absolute, now margin for error. The client
+    // should refresh the token X second before it expires.
+    const unixTime = Math.floor(Date.now() / 1000);
+    if (!payload.exp || payload.exp < unixTime) {
+      throw new TokenExpiredError("JWT expired");
+    }
 
-		const payload = result.payload;
-		const knownKeys = ["state", "iat", "exp", "aud", "iss"];
-		for (const k in payload) {
-			if (!knownKeys.includes(k)) {
-				this.refreshTokens[k] = payload[k] as string;
-			}
-		}
-	}
+    if (fingerprint && !validateFingerprint(fingerprint, payload._fingerprint)) {
+      throw new TokenInvalidError("Invalid fingerprint")
+    }
 
-	encryptTokens(signer: TokenSigner) {
-		const value = JSON.stringify(this.tokens);
-		return signer.encryptString(value);
-	}
+    this.tokens = this.decryptTokens(signer, payload.state as string);
+    const knownKeys = ["state", "iat", "exp", "aud", "iss"];
+    for (const k in payload) {
+      if (!knownKeys.includes(k)) {
+        this.values[k] = payload[k];
+      }
+    }
+  }
 
-	decryptTokens(signer: TokenSigner, value: string) {
-		const data = signer.decryptString(value);
-		return JSON.parse(data);
-	}
+  // createRefreshJWT encrypts the refresh token and return a JWT. The token is
+  // valid for 90 days.
+  async createRefreshJWT(signer: TokenSigner) {
+    const payload = this.refreshTokens;
+    const exp = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 90;
+    return signer.encryptJWT(payload, exp);
+  }
+
+  async loadRefreshJWT(signer: TokenSigner, value: string) {
+    const result = await signer.decryptJWT(value);
+    if (!result) {
+      throw new Error("Invalid JWT");
+    }
+
+    const payload = result.payload;
+    const knownKeys = ["state", "iat", "exp", "aud", "iss"];
+    for (const k in payload) {
+      if (!knownKeys.includes(k)) {
+        this.refreshTokens[k] = payload[k] as string;
+      }
+    }
+  }
+
+  encryptTokens(signer: TokenSigner) {
+    const value = JSON.stringify(this.tokens);
+    return signer.encryptString(value);
+  }
+
+  decryptTokens(signer: TokenSigner, value: string) {
+    const data = signer.decryptString(value);
+    return JSON.parse(data);
+  }
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -92,11 +92,10 @@ export class FederatedToken {
 
 		// Merge tokens in object
 		for (const k in refreshTokens) {
-			this.refreshTokens[k] = refreshTokens[k];
-
 			if (trackModified && !isEqual(this.refreshTokens[k], refreshTokens[k])) {
 				this._refreshTokenModified = true;
 			}
+			this.refreshTokens[k] = refreshTokens[k];
 		}
 	}
 

--- a/src/tokensource.test.ts
+++ b/src/tokensource.test.ts
@@ -1,0 +1,121 @@
+import {
+  CompositeTokenSource,
+  TokenSource,
+  CookieTokenSource,
+  HeaderTokenSource,
+} from "./tokensource";
+import httpMocks from "node-mocks-http";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock tokens
+const mockAccessToken = "mockAccessToken";
+const mockRefreshToken = "mockRefreshToken";
+
+describe("CompositeTokenSource", () => {
+  // Helper function to create a mock TokenSource with empty implementations
+  const createMockTokenSource = (): TokenSource => ({
+    getAccessToken: vi.fn().mockReturnValue(""),
+    getRefreshToken: vi.fn().mockReturnValue(""),
+    getFingerprint: vi.fn().mockReturnValue(""),
+    setAccessToken: vi.fn(),
+    setRefreshToken: vi.fn(),
+    setFingerprint: vi.fn(),
+  });
+
+  it("should get the access token from the first source that provides one", () => {
+    const mockTokenSource1 = createMockTokenSource();
+    const mockTokenSource2 = createMockTokenSource();
+    mockTokenSource2.getAccessToken = vi.fn().mockReturnValue(mockAccessToken);
+
+    const request = httpMocks.createRequest();
+    const compositeTokenSource = new CompositeTokenSource([
+      mockTokenSource1,
+      mockTokenSource2,
+    ]);
+    const result = compositeTokenSource.getAccessToken(request);
+
+    expect(result).toBe(mockAccessToken);
+    expect(mockTokenSource1.getAccessToken).toHaveBeenCalled();
+    expect(mockTokenSource2.getAccessToken).toHaveBeenCalled();
+  });
+});
+
+describe("CookieTokenSource", () => {
+  it("should get the access token from cookies", () => {
+    const request = httpMocks.createRequest();
+    request.cookies = { authToken: "FOOBAR" };
+
+    const cookieTokenSource = new CookieTokenSource({
+      secure: true,
+      sameSite: "strict",
+      refreshTokenPath: "/refresh",
+    });
+    const result = cookieTokenSource.getAccessToken(request);
+    expect(result).toBe("FOOBAR");
+  });
+
+  it("should get the refresh token from cookies", () => {
+    const request = httpMocks.createRequest();
+    request.cookies = { authRefreshToken: "FOOBAR" };
+
+    const cookieTokenSource = new CookieTokenSource({
+      secure: true,
+      sameSite: "strict",
+      refreshTokenPath: "/refresh",
+    });
+    const result = cookieTokenSource.getRefreshToken(request);
+    expect(result).toBe("FOOBAR");
+  });
+});
+
+describe("HeaderTokenSource", () => {
+  it("should get the access token from headers", () => {
+    const headerTokenSource = new HeaderTokenSource();
+    const request = httpMocks.createRequest({
+      headers: { "x-access-token": `Bearer FOOBAR` },
+    });
+    const result = headerTokenSource.getAccessToken(request);
+    expect(result).toBe("FOOBAR");
+  });
+
+  it("should get the refresh token from headers", () => {
+    const headerTokenSource = new HeaderTokenSource();
+    const request = httpMocks.createRequest({
+      headers: {
+        "x-refresh-token": mockRefreshToken,
+      },
+    });
+    const result = headerTokenSource.getRefreshToken(request);
+
+    expect(result).toBe(mockRefreshToken);
+  });
+
+  it("should return an undefined value if access token is missing from headers", () => {
+    const headerTokenSource = new HeaderTokenSource();
+    const request = httpMocks.createRequest();
+    const result = headerTokenSource.getAccessToken(request);
+    expect(result).toBeUndefined();
+  });
+
+  it("should set the access token in the response headers", () => {
+    const response = httpMocks.createResponse();
+    const headerTokenSource = new HeaderTokenSource();
+    headerTokenSource.setAccessToken(response, "foobar");
+    expect(response.get("x-access-token")).toBe("foobar");
+  });
+
+  it("should set the refresh token in the response headers", () => {
+    const response = httpMocks.createResponse();
+    const headerTokenSource = new HeaderTokenSource();
+    headerTokenSource.setRefreshToken(response, "foobar");
+    expect(response.get("x-refresh-token")).toBe("foobar");
+  });
+
+  it("should not set the fingerprint in the response headers", () => {
+    const response = httpMocks.createResponse();
+    const headerTokenSource = new HeaderTokenSource();
+    headerTokenSource.setFingerprint(response, "mockFingerprint");
+
+    expect(response.getHeaders()).toStrictEqual({});
+  });
+});

--- a/src/tokensource.ts
+++ b/src/tokensource.ts
@@ -1,0 +1,169 @@
+import { CookieOptions, Request, Response } from "express";
+
+export interface TokenSource {
+  getAccessToken(request: Request): string;
+  getRefreshToken(request: Request): string;
+  getFingerprint(request: Request): string;
+  setAccessToken(response: Response, token: string): void;
+  setRefreshToken(response: Response, token: string): void;
+  setFingerprint(response: Response, fingerprint: string): void;
+}
+
+export class CompositeTokenSource implements TokenSource {
+  private sources: TokenSource[];
+
+  constructor(sources: TokenSource[]) {
+    this.sources = sources;
+  }
+
+  getAccessToken(request: Request): string {
+    for (const source of this.sources) {
+      const token = source.getAccessToken(request);
+      if (token) {
+        return token;
+      }
+    }
+    return "";
+  }
+
+  getRefreshToken(request: Request): string {
+    for (const source of this.sources) {
+      const token = source.getRefreshToken(request);
+      if (token) {
+        return token;
+      }
+    }
+    return "";
+  }
+
+  getFingerprint(request: Request): string {
+    for (const source of this.sources) {
+      const token = source.getFingerprint(request);
+      if (token) {
+        return token;
+      }
+    }
+    return "";
+  }
+
+  setAccessToken(response: Response, token: string) {
+    for (const source of this.sources) {
+      source.setAccessToken(response, token);
+    }
+  }
+
+  setRefreshToken(response: Response, token: string) {
+    for (const source of this.sources) {
+      source.setRefreshToken(response, token);
+    }
+  }
+
+  setFingerprint(response: Response, fingerprint: string) {
+    for (const source of this.sources) {
+      source.setFingerprint(response, fingerprint);
+    }
+  }
+}
+
+type CookieSourceOptions = {
+  secure: boolean;
+  sameSite: CookieOptions["sameSite"];
+  refreshTokenPath: string;
+};
+
+/*
+ * CookieTokenSource is a TokenSource that uses cookies to store the tokens. It
+ * uses the following four cookies for storing the token securely by mixing
+ * httpOnly and non-httpOnly cookies:
+ *  - accessToken: The access token (non-httpOnly)
+ *  - refreshToken: The refresh token (httpOnly)
+ *  - refreshTokenExist: A flag to indicate that the refresh token exists (non-httpOnly)
+ *  - accessTokenFingerprint: The fingerprint of the browser (httpOnly)
+ */
+export class CookieTokenSource implements TokenSource {
+  constructor(private options: CookieSourceOptions) {}
+
+  cookieNames = {
+    accessToken: "authToken",
+    accessTokenFingerprint: "authTokenHash",
+    refreshToken: "authRefreshToken",
+    refreshTokenExist: "authRefreshTokenExist",
+  };
+
+  getAccessToken(request: Request): string {
+    return request.cookies[this.cookieNames.accessToken];
+  }
+
+  getRefreshToken(request: Request): string {
+    return request.cookies[this.cookieNames.refreshToken];
+  }
+
+  getFingerprint(request: Request): string {
+    return request.cookies[this.cookieNames.accessTokenFingerprint];
+  }
+
+  setAccessToken(response: Response, token: string) {
+    response.cookie(this.cookieNames.accessToken, token, {
+      httpOnly: false,
+      secure: this.options.secure,
+      sameSite: this.options.sameSite,
+    });
+  }
+
+  setRefreshToken(response: Response, token: string) {
+    const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365);
+    response.cookie(this.cookieNames.refreshToken, token, {
+      httpOnly: true,
+      path: this.options.refreshTokenPath,
+      secure: this.options.secure,
+      sameSite: this.options.sameSite,
+      expires: expiresAt,
+    });
+
+    response.cookie(this.cookieNames.refreshTokenExist, "1", {
+      httpOnly: false,
+      secure: this.options.secure,
+      sameSite: this.options.sameSite,
+      expires: expiresAt,
+    });
+  }
+
+  setFingerprint(response: Response, fingerprint: string) {
+    response.cookie(this.cookieNames.accessTokenFingerprint, fingerprint, {
+      path: "/graphql",
+      httpOnly: true,
+      secure: this.options.secure,
+      sameSite: this.options.sameSite,
+    });
+  }
+}
+
+export class HeaderTokenSource implements TokenSource {
+  headerNames = {
+    accessToken: "x-access-token",
+    refreshToken: "x-refresh-token",
+  }
+
+  getAccessToken(request: Request): string {
+    const authHeader = request.headers[this.headerNames.accessToken] as string;
+    return authHeader?.replace("Bearer ", "");
+  }
+
+  getRefreshToken(request: Request): string {
+    return request.headers[this.headerNames.refreshToken] as string;
+  }
+
+  getFingerprint(request: Request): string {
+    return "";
+  }
+
+  setAccessToken(response: Response, token: string) {
+    response.set(this.headerNames.accessToken, token);
+  }
+
+  setRefreshToken(response: Response, token: string) {
+    response.set(this.headerNames.refreshToken, token);
+  }
+
+  setFingerprint(response: Response, fingerprint: string) {}
+}


### PR DESCRIPTION
This introduces TokenSource interface which allows us to retrieve the
tokens either from cookies or from headers (or both).

When cookies are used it also adds additional security items like
fingerprints and setting some cookies as http-only and some not
