### PR TITLE
Implement cookie domain

### DIFF
--- a/.changeset/itchy-singers-add.md
+++ b/.changeset/itchy-singers-add.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/federated-token": minor
+---
+
+Implement cookie domain options

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -92,7 +92,7 @@ export class GatewayAuthPlugin<TContext extends PublicFederatedTokenContext>
 	): Promise<void> {
 		const { contextValue } = requestContext;
 		const token = contextValue?.federatedToken;
-		const response = contextValue.res;
+		const { req: request, res: response } = contextValue;
 
 		if (token?.isAccessTokenModified()) {
 			const { accessToken, fingerprint } = await token.createAccessJWT(
@@ -100,14 +100,14 @@ export class GatewayAuthPlugin<TContext extends PublicFederatedTokenContext>
 			);
 
 			if (accessToken && fingerprint) {
-				this.tokenSource.setAccessToken(response, accessToken);
-				this.tokenSource.setFingerprint(response, fingerprint);
+				this.tokenSource.setAccessToken(request, response, accessToken);
+				this.tokenSource.setFingerprint(request, response, fingerprint);
 			}
 		}
 
 		if (token?.isRefreshTokenModified()) {
 			const refreshToken = await token.createRefreshJWT(this.signer);
-			this.tokenSource.setRefreshToken(response, refreshToken);
+			this.tokenSource.setRefreshToken(request, response, refreshToken);
 		}
 	}
 }

--- a/src/tokensource/base.ts
+++ b/src/tokensource/base.ts
@@ -4,7 +4,11 @@ export interface TokenSource {
 	getAccessToken(request: Request): string;
 	getRefreshToken(request: Request): string;
 	getFingerprint(request: Request): string;
-	setAccessToken(response: Response, token: string): void;
-	setRefreshToken(response: Response, token: string): void;
-	setFingerprint(response: Response, fingerprint: string): void;
+	setAccessToken(request: Request, response: Response, token: string): void;
+	setRefreshToken(request: Request, response: Response, token: string): void;
+	setFingerprint(
+		request: Request,
+		response: Response,
+		fingerprint: string
+	): void;
 }

--- a/src/tokensource/composite.ts
+++ b/src/tokensource/composite.ts
@@ -38,21 +38,21 @@ export class CompositeTokenSource implements TokenSource {
 		return "";
 	}
 
-	setAccessToken(response: Response, token: string) {
+	setAccessToken(request: Request, response: Response, token: string) {
 		for (const source of this.sources) {
-			source.setAccessToken(response, token);
+			source.setAccessToken(request, response, token);
 		}
 	}
 
-	setRefreshToken(response: Response, token: string) {
+	setRefreshToken(request: Request, response: Response, token: string) {
 		for (const source of this.sources) {
-			source.setRefreshToken(response, token);
+			source.setRefreshToken(request, response, token);
 		}
 	}
 
-	setFingerprint(response: Response, fingerprint: string) {
+	setFingerprint(request: Request, response: Response, fingerprint: string) {
 		for (const source of this.sources) {
-			source.setFingerprint(response, fingerprint);
+			source.setFingerprint(request, response, fingerprint);
 		}
 	}
 }

--- a/src/tokensource/cookies.ts
+++ b/src/tokensource/cookies.ts
@@ -5,6 +5,8 @@ type CookieSourceOptions = {
 	secure: boolean;
 	sameSite: CookieOptions["sameSite"];
 	refreshTokenPath: string;
+	publicDomainFn?: (request: Request) => string | undefined;
+	privateDomainFn?: (request: Request) => string | undefined;
 };
 
 /*
@@ -57,15 +59,16 @@ export class CookieTokenSource implements TokenSource {
 		return this._getCookie(request, this.cookieNames.accessTokenHash);
 	}
 
-	setAccessToken(response: Response, token: string) {
+	setAccessToken(request: Request, response: Response, token: string) {
 		this._setCookie(response, this.cookieNames.accessToken, token, {
 			httpOnly: false,
 			secure: this.options.secure,
 			sameSite: this.options.sameSite,
+			domain: this.options?.publicDomainFn?.(request),
 		});
 	}
 
-	setRefreshToken(response: Response, token: string) {
+	setRefreshToken(request: Request, response: Response, token: string) {
 		const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365);
 		this._setCookie(response, this.cookieNames.refreshToken, token, {
 			httpOnly: true,
@@ -73,6 +76,7 @@ export class CookieTokenSource implements TokenSource {
 			secure: this.options.secure,
 			sameSite: this.options.sameSite,
 			expires: expiresAt,
+			domain: this.options?.privateDomainFn?.(request),
 		});
 
 		this._setCookie(response, this.cookieNames.refreshTokenExist, "1", {
@@ -80,14 +84,16 @@ export class CookieTokenSource implements TokenSource {
 			secure: this.options.secure,
 			sameSite: this.options.sameSite,
 			expires: expiresAt,
+			domain: this.options?.publicDomainFn?.(request),
 		});
 	}
 
-	setFingerprint(response: Response, fingerprint: string) {
+	setFingerprint(request: Request, response: Response, fingerprint: string) {
 		this._setCookie(response, this.cookieNames.accessTokenHash, fingerprint, {
 			httpOnly: true,
 			secure: this.options.secure,
 			sameSite: this.options.sameSite,
+			domain: this.options?.privateDomainFn?.(request),
 		});
 	}
 }

--- a/src/tokensource/headers.test.ts
+++ b/src/tokensource/headers.test.ts
@@ -35,23 +35,26 @@ describe("HeaderTokenSource", () => {
 	});
 
 	it("should set the access token in the response headers", () => {
+		const request = httpMocks.createRequest();
 		const response = httpMocks.createResponse();
 		const headerTokenSource = new HeaderTokenSource();
-		headerTokenSource.setAccessToken(response, "foobar");
+		headerTokenSource.setAccessToken(request, response, "foobar");
 		expect(response.get("x-access-token")).toBe("foobar");
 	});
 
 	it("should set the refresh token in the response headers", () => {
+		const request = httpMocks.createRequest();
 		const response = httpMocks.createResponse();
 		const headerTokenSource = new HeaderTokenSource();
-		headerTokenSource.setRefreshToken(response, "foobar");
+		headerTokenSource.setRefreshToken(request, response, "foobar");
 		expect(response.get("x-refresh-token")).toBe("foobar");
 	});
 
 	it("should not set the fingerprint in the response headers", () => {
+		const request = httpMocks.createRequest();
 		const response = httpMocks.createResponse();
 		const headerTokenSource = new HeaderTokenSource();
-		headerTokenSource.setFingerprint(response, "mockFingerprint");
+		headerTokenSource.setFingerprint(request, response, "mockFingerprint");
 
 		expect(response.getHeaders()).toStrictEqual({});
 	});

--- a/src/tokensource/headers.ts
+++ b/src/tokensource/headers.ts
@@ -20,13 +20,13 @@ export class HeaderTokenSource implements TokenSource {
 		return "";
 	}
 
-	setAccessToken(response: Response, token: string) {
+	setAccessToken(request: Request, response: Response, token: string) {
 		response.set(this.headerNames.accessToken, token);
 	}
 
-	setRefreshToken(response: Response, token: string) {
+	setRefreshToken(request: Request, response: Response, token: string) {
 		response.set(this.headerNames.refreshToken, token);
 	}
 
-	setFingerprint(response: Response, fingerprint: string) {}
+	setFingerprint(request: Request, response: Response, fingerprint: string) {}
 }


### PR DESCRIPTION
Add options to `CookieTokenSource` to set cookie domain. 

- `publicDomainFn` set domain for non-httponly cookies
- `privateDomainFn` set domain for httponly cookies