### PR TITLE
Check for values modified in deserializeAccessToken

### DIFF
--- a/.changeset/giant-badgers-clap.md
+++ b/.changeset/giant-badgers-clap.md
@@ -1,0 +1,9 @@
+---
+"@labdigital/federated-token": patch
+---
+
+Check for values modified in deserializeAccessToken
+
+When you only set a value in a service, the token did not get updated in the gateway.
+This was because the valueModified was only set after a token change, not just a value change.
+This changes improves the check to fix that.

--- a/src/token.test.ts
+++ b/src/token.test.ts
@@ -136,6 +136,10 @@ describe("FederatedToken", () => {
 			federatedToken.isAccessTokenModified(),
 			"isModified should be true when trackModified is true and token is modified"
 		);
+		assert.isTrue(
+			federatedToken.isValueModified(),
+			"isModified should be true when trackModified is true and value is modified"
+		);
 	});
 
 	test("serializeAccessToken", () => {

--- a/src/token.ts
+++ b/src/token.ts
@@ -93,13 +93,13 @@ export class FederatedToken {
 			Buffer.from(at, "base64").toString("ascii")
 		);
 
-		this._valueModified = trackModified && !isEqual(this.values, token.values);
+		if (trackModified) {
+			this._valueModified = !isEqual(this.values, token.values);
 
-		this._accessTokenModified =
-			trackModified &&
-			Object.keys(token.tokens).some(
+			this._accessTokenModified = Object.keys(token.tokens).some(
 				(key) => !isEqual(this.tokens[key], token.tokens[key])
 			);
+		}
 
 		// Merge tokens and values into "this" object.
 		this.tokens = {

--- a/src/token.ts
+++ b/src/token.ts
@@ -93,15 +93,13 @@ export class FederatedToken {
 			Buffer.from(at, "base64").toString("ascii")
 		);
 
-		// The value is modified if:
-		this._valueModified =
+		this._valueModified = trackModified && !isEqual(this.values, token.values);
+
+		this._accessTokenModified =
 			trackModified &&
-			// either a value has been modified
-			(!isEqual(this.values, token.values) ||
-				// or at least 1 token has been modified
-				Object.keys(token.tokens).some(
-					(key) => !isEqual(this.tokens[key], token.tokens[key])
-				));
+			Object.keys(token.tokens).some(
+				(key) => !isEqual(this.tokens[key], token.tokens[key])
+			);
 
 		// Merge tokens and values into "this" object.
 		this.tokens = {

--- a/src/token.ts
+++ b/src/token.ts
@@ -93,12 +93,17 @@ export class FederatedToken {
 			Buffer.from(at, "base64").toString("ascii")
 		);
 
-		// Merge tokens into this object. Checking for modified tokens
-		for (const k in token.tokens) {
-			if (trackModified && !isEqual(this.tokens[k], token.tokens[k])) {
-				this._accessTokenModified = true;
-			}
-		}
+		// The value is modified if:
+		this._valueModified =
+			trackModified &&
+			// either a value has been modified
+			(!isEqual(this.values, token.values) ||
+				// or at least 1 token has been modified
+				Object.keys(token.tokens).some(
+					(key) => !isEqual(this.tokens[key], token.tokens[key])
+				));
+
+		// Merge tokens and values into "this" object.
 		this.tokens = {
 			...this.tokens,
 			...token.tokens,


### PR DESCRIPTION
When you only set a value in a service, the token did not get updated in the gateway.
This was because the valueModified was only set after a token change, not just a value change.
This PR improves the check to fix that.