### PR TITLE
(de)serialize values for refresh tokens

### DIFF
--- a/.changeset/ten-goats-fly.md
+++ b/.changeset/ten-goats-fly.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/federated-token": patch
+---
+
+(de)serialize values for refresh tokens

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -57,7 +57,7 @@ export class FederatedGraphQLDataSource<
 			if (!context.federatedToken) {
 				context.federatedToken = new PublicFederatedToken();
 			}
-			context.federatedToken.loadRefreshToken(refreshToken, true);
+			context.federatedToken.deserializeRefreshToken(refreshToken, true);
 		}
 		return response;
 	}

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -110,12 +110,12 @@ export class PublicFederatedToken extends FederatedToken {
 			jwe: await signer.encryptObject(this.refreshTokens),
 		};
 
-		const token = await signer.signJWT(payload);
+		const token = await signer.encryptJWT(payload, exp);
 		return token;
 	}
 
 	async loadRefreshJWT(signer: TokenSigner, value: string) {
-		const result = await signer.verifyJWT(value);
+		const result = await signer.decryptJWT(value);
 		if (!result) {
 			throw new Error("Invalid JWT");
 		}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -27,7 +27,7 @@ export class FederatedAuthPlugin<TContext extends FederatedTokenContext>
 
 		const rt = request.http?.headers.get("X-Refresh-Token");
 		if (rt) {
-			contextValue.federatedToken.loadRefreshToken(rt);
+			contextValue.federatedToken.deserializeRefreshToken(rt);
 		}
 		return this;
 	}
@@ -51,7 +51,7 @@ export class FederatedAuthPlugin<TContext extends FederatedTokenContext>
 		}
 
 		if (t.isRefreshTokenModified()) {
-			const val = t.dumpRefreshToken();
+			const val = t.serializeRefreshToken();
 			if (val) {
 				response.http.headers.set("X-Refresh-Token", val);
 			}

--- a/src/token.test.ts
+++ b/src/token.test.ts
@@ -173,15 +173,20 @@ describe("FederatedToken", () => {
 		assert.equal(federatedToken.serializeAccessToken(), serialized);
 	});
 
-	test("loadRefreshToken", () => {
+	test("deserializeRefreshToken", () => {
 		const value = Buffer.from(
 			JSON.stringify({
-				exampleName: "exampleToken",
+				refreshTokens: {
+					exampleName: "exampleToken",
+				},
+				values: {
+					test: 1,
+				},
 			})
 		).toString("base64");
 
 		const federatedToken = new FederatedToken();
-		federatedToken.loadRefreshToken(value);
+		federatedToken.deserializeRefreshToken(value);
 
 		assert.deepStrictEqual(
 			federatedToken.refreshTokens,
@@ -190,20 +195,31 @@ describe("FederatedToken", () => {
 			},
 			"Refresh tokens should be loaded correctly"
 		);
+		assert.deepStrictEqual(
+			federatedToken.values,
+			{
+				test: 1,
+			},
+			"Values of Refresh tokens should be loaded correctly"
+		);
 	});
 
-	test("dumpRefreshToken", () => {
+	test("serializeRefreshToken", () => {
 		const federatedToken = new FederatedToken();
 		federatedToken.refreshTokens = {
 			exampleName: "exampleToken",
 		};
+		federatedToken.values = { test: 1 };
 
 		const expectedDump = Buffer.from(
 			JSON.stringify({
-				exampleName: "exampleToken",
+				refreshTokens: {
+					exampleName: "exampleToken",
+				},
+				values: { test: 1 },
 			})
 		).toString("base64");
 
-		assert.equal(federatedToken.dumpRefreshToken(), expectedDump);
+		assert.equal(federatedToken.serializeRefreshToken(), expectedDump);
 	});
 });


### PR DESCRIPTION
When you have a federated token that contains values, the values got lost after refreshing.

This was especially a problem in systems that use values for specific logic.
For instance, using anonymous queries or authenticated queries based on an `anonymous` value.
The access token might be created for an authenticated user, but then after the refresh, the system thought it would be an anonymous token because the value was lost.