### PR TITLE
Handle invalid refresh tokens by deleting them

### DIFF
--- a/.changeset/quick-socks-whisper.md
+++ b/.changeset/quick-socks-whisper.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/federated-token": minor
+---
+
+Delete refreshToken if invalid

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -4,7 +4,7 @@ import {
 } from "@apollo/gateway";
 import { HeaderMap } from "@apollo/server";
 import { type GatewayGraphQLResponse } from "@apollo/server-gateway-interface";
-import { PublicFederatedToken, PublicFederatedTokenContext } from "./jwt.js";
+import { PublicFederatedToken, PublicFederatedTokenContext } from "./jwt";
 
 // FederatedGraphQLDataSource is a RemoteGraphQLDataSource that adds the
 // x-access-token and x-refresh-token headers to the request and reads the

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,19 @@
+import * as jose from "jose";
+
+export class TokenExpiredError extends Error {}
+
+export class TokenInvalidError extends Error {}
+
+export const createError = (e: unknown): Error => {
+	if (e instanceof jose.errors.JWTClaimValidationFailed) {
+		return new TokenExpiredError(e.message);
+	}
+	if (e instanceof jose.errors.JWTExpired) {
+		return new TokenExpiredError(e.message);
+	}
+	if (e instanceof Error) {
+		return new TokenInvalidError(e.message);
+	}
+
+	return new TokenInvalidError();
+};

--- a/src/gateway.test.ts
+++ b/src/gateway.test.ts
@@ -2,9 +2,9 @@ import { ApolloServer, HeaderMap } from "@apollo/server";
 import * as crypto from "crypto";
 import httpMocks from "node-mocks-http";
 import { assert, describe, expect, it } from "vitest";
-import { GatewayAuthPlugin } from "./gateway.js";
-import { PublicFederatedToken, PublicFederatedTokenContext } from "./jwt.js";
-import { KeyManager, TokenSigner } from "./sign.js";
+import { GatewayAuthPlugin } from "./gateway";
+import { PublicFederatedToken, PublicFederatedTokenContext } from "./jwt";
+import { KeyManager, TokenSigner } from "./sign";
 import { HeaderTokenSource } from "./tokensource";
 
 describe("GatewayAuthPlugin", () => {

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -4,13 +4,10 @@ import {
 	type GraphQLRequestListener,
 } from "@apollo/server";
 import { GraphQLError } from "graphql";
-import {
-	PublicFederatedToken,
-	PublicFederatedTokenContext,
-	TokenExpiredError,
-} from "./jwt.js";
+import { PublicFederatedToken, PublicFederatedTokenContext } from "./jwt";
 import { TokenSigner } from "./sign";
 import { TokenSource } from "./tokensource";
+import { TokenExpiredError } from "./errors";
 
 type GatewayOptions = {
 	signer: TokenSigner;
@@ -94,7 +91,11 @@ export class GatewayAuthPlugin<TContext extends PublicFederatedTokenContext>
 		}
 
 		if (refreshToken) {
-			await token.loadRefreshJWT(this.signer, refreshToken);
+			try {
+				await token.loadRefreshJWT(this.signer, refreshToken);
+			} catch (e: unknown) {
+				this.tokenSource.deleteRefreshToken(contextValue.res);
+			}
 		}
 	}
 

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -65,8 +65,9 @@ export class GatewayAuthPlugin<TContext extends PublicFederatedTokenContext>
 			try {
 				await token.loadAccessJWT(this.signer, accessToken, fingerprint);
 			} catch (e: unknown) {
+				this.tokenSource.deleteAccessToken(contextValue.res);
+
 				if (e instanceof TokenExpiredError) {
-					this.tokenSource.deleteAccessToken(contextValue.res);
 					throw new GraphQLError("Your token has expired.", {
 						extensions: {
 							code: "UNAUTHENTICATED",
@@ -76,8 +77,6 @@ export class GatewayAuthPlugin<TContext extends PublicFederatedTokenContext>
 						},
 					});
 				} else {
-					this.tokenSource.deleteAccessToken(contextValue.res);
-					this.tokenSource.deleteRefreshToken(contextValue.res);
 					throw new GraphQLError("Your token is invalid.", {
 						extensions: {
 							code: "INVALID_TOKEN",

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -9,7 +9,7 @@ import {
 	PublicFederatedTokenContext,
 	TokenExpiredError,
 } from "./jwt.js";
-import { TokenSigner } from "./sign.js";
+import { TokenSigner } from "./sign";
 import { TokenSource } from "./tokensource";
 
 type GatewayOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,12 @@
-export { FederatedGraphQLDataSource } from "./datasource.js";
-export { GatewayAuthPlugin } from "./gateway.js";
-export {
-	PublicFederatedToken,
-	type PublicFederatedTokenContext,
-} from "./jwt.js";
-export { FederatedAuthPlugin } from "./plugin.js";
-export { KeyManager, TokenSigner, type KeyManagerInterface } from "./sign.js";
-export { FederatedToken } from "./token.js";
+export { FederatedGraphQLDataSource } from "./datasource";
+export { GatewayAuthPlugin } from "./gateway";
+export { PublicFederatedToken, type PublicFederatedTokenContext } from "./jwt";
+export { FederatedAuthPlugin } from "./plugin";
+export { KeyManager, TokenSigner, type KeyManagerInterface } from "./sign";
+export { FederatedToken } from "./token";
 export {
 	CompositeTokenSource,
 	CookieTokenSource,
 	HeaderTokenSource,
 	type TokenSource,
-} from "./tokensource/index.js";
+} from "./tokensource/index";

--- a/src/jwt.test.ts
+++ b/src/jwt.test.ts
@@ -1,8 +1,8 @@
 import * as crypto from "crypto";
 import { describe, expect, test } from "vitest";
-import { generateFingerprint, hashFingerprint } from "./fingerprint.js";
-import { PublicFederatedToken } from "./jwt.js";
-import { KeyManager, TokenSigner } from "./sign.js";
+import { generateFingerprint, hashFingerprint } from "./fingerprint";
+import { PublicFederatedToken } from "./jwt";
+import { KeyManager, TokenSigner } from "./sign";
 
 describe("PublicFederatedToken", async () => {
 	const signOptions = {

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -4,9 +4,9 @@ import {
 	generateFingerprint,
 	hashFingerprint,
 	validateFingerprint,
-} from "./fingerprint.js";
-import { TokenSigner } from "./sign.js";
-import { FederatedToken } from "./token.js";
+} from "./fingerprint";
+import { TokenSigner } from "./sign";
+import { FederatedToken } from "./token";
 
 export type PublicFederatedTokenContext = {
 	federatedToken?: PublicFederatedToken;

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -7,6 +7,7 @@ import {
 } from "./fingerprint";
 import { TokenSigner } from "./sign";
 import { FederatedToken } from "./token";
+import { TokenExpiredError, TokenInvalidError } from "./errors";
 
 export type PublicFederatedTokenContext = {
 	federatedToken?: PublicFederatedToken;
@@ -20,10 +21,6 @@ type JWTPayload = {
 	_fingerprint: string;
 	[key: string]: any;
 };
-
-export class TokenExpiredError extends Error {}
-
-export class TokenInvalidError extends Error {}
 
 export class PublicFederatedToken extends FederatedToken {
 	// Create the access JWT. This JWT is send to the client. It is send as
@@ -107,7 +104,7 @@ export class PublicFederatedToken extends FederatedToken {
 	async loadRefreshJWT(signer: TokenSigner, value: string) {
 		const result = await signer.decryptJWT(value);
 		if (!result) {
-			throw new Error("Invalid JWT");
+			throw new TokenInvalidError("Invalid JWT");
 		}
 
 		const payload = result.payload;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import {
 	type GraphQLRequestContext,
 	type GraphQLRequestListener,
 } from "@apollo/server";
-import { FederatedToken, FederatedTokenContext } from "./token.js";
+import { FederatedToken, FederatedTokenContext } from "./token";
 
 // FederatedAuthPlugin is an Apollo plugin which should be used by all
 // downstream services. It reads the information from the request headers as

--- a/src/sign.test.ts
+++ b/src/sign.test.ts
@@ -1,6 +1,6 @@
 import * as crypto from "crypto";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { KeyManager, TokenSigner } from "./sign.js";
+import { KeyManager, TokenSigner } from "./sign";
 
 describe("Strings", async () => {
 	const signOptions = {

--- a/src/token.test.ts
+++ b/src/token.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, test } from "vitest";
-import { AccessToken, FederatedToken } from "./token.js";
+import { AccessToken, FederatedToken } from "./token";
 
 describe("FederatedToken", () => {
 	test("setAccessToken", () => {

--- a/src/tokensource/composite.test.ts
+++ b/src/tokensource/composite.test.ts
@@ -1,7 +1,7 @@
 import httpMocks from "node-mocks-http";
 import { describe, expect, it, vi } from "vitest";
-import { TokenSource } from "./base.js";
-import { CompositeTokenSource } from "./composite.js";
+import { TokenSource } from "./base";
+import { CompositeTokenSource } from "./composite";
 
 // Mock tokens
 const mockAccessToken = "mockAccessToken";

--- a/src/tokensource/composite.ts
+++ b/src/tokensource/composite.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { TokenSource } from "./base.js";
+import { TokenSource } from "./base";
 
 export class CompositeTokenSource implements TokenSource {
 	private sources: TokenSource[];

--- a/src/tokensource/cookies.test.ts
+++ b/src/tokensource/cookies.test.ts
@@ -1,6 +1,6 @@
 import httpMocks from "node-mocks-http";
 import { describe, it, expect } from "vitest";
-import { CookieTokenSource } from "./cookies.js";
+import { CookieTokenSource } from "./cookies";
 import { CookieSerializeOptions } from "cookie";
 
 const createMockResponse = () => {

--- a/src/tokensource/cookies.ts
+++ b/src/tokensource/cookies.ts
@@ -1,5 +1,5 @@
 import { CookieOptions, Request, Response } from "express";
-import { TokenSource } from "./base.js";
+import { TokenSource } from "./base";
 
 type CookieSourceOptions = {
 	secure: boolean;

--- a/src/tokensource/headers.test.ts
+++ b/src/tokensource/headers.test.ts
@@ -1,6 +1,6 @@
 import httpMocks from "node-mocks-http";
 import { describe, expect, it } from "vitest";
-import { HeaderTokenSource } from "./headers.js";
+import { HeaderTokenSource } from "./headers";
 
 // Mock tokens
 const mockRefreshToken = "mockRefreshToken";

--- a/src/tokensource/headers.ts
+++ b/src/tokensource/headers.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { TokenSource } from "./base.js";
+import { TokenSource } from "./base";
 
 export class HeaderTokenSource implements TokenSource {
 	headerNames = {

--- a/src/tokensource/index.ts
+++ b/src/tokensource/index.ts
@@ -1,4 +1,4 @@
-export { type TokenSource } from "./base.js";
-export { CompositeTokenSource } from "./composite.js";
-export { CookieTokenSource } from "./cookies.js";
-export { HeaderTokenSource } from "./headers.js";
+export { type TokenSource } from "./base";
+export { CompositeTokenSource } from "./composite";
+export { CookieTokenSource } from "./cookies";
+export { HeaderTokenSource } from "./headers";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
 		"composite": false,
 		"esModuleInterop": true,
 		"experimentalDecorators": true,
-		"baseUrl": "./src/",
 		"isolatedModules": true,
 		"module": "ES2022",
 		"moduleResolution": "bundler",


### PR DESCRIPTION
- chore: remove `.js` from import statements
- refactor: wrap all jose errors with our own
- chore: refactor deleting of invalid tokens
