### PR TITLE
feat: add cookieNames option to CookieTokenSource constructor

### DIFF
--- a/.changeset/sharp-chicken-explode.md
+++ b/.changeset/sharp-chicken-explode.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/federated-token": minor
+---
+
+Add cookienames option to CookieTokenSource constructor

--- a/src/tokensource/cookies.test.ts
+++ b/src/tokensource/cookies.test.ts
@@ -20,7 +20,6 @@ const createMockResponse = () => {
 };
 
 describe("CookieTokenSource", () => {
-
 	it("should use default cookie names", () => {
 		const cookieTokenSource = new CookieTokenSource({
 			secure: false,
@@ -28,7 +27,7 @@ describe("CookieTokenSource", () => {
 			refreshTokenPath: "/refresh",
 		});
 
-		const result = cookieTokenSource['cookieNames']
+		const result = cookieTokenSource["cookieNames"];
 		expect(result).toStrictEqual({
 			accessToken: "authToken",
 			accessTokenHash: "authTokenHash",
@@ -43,19 +42,19 @@ describe("CookieTokenSource", () => {
 			sameSite: "strict",
 			refreshTokenPath: "/refresh",
 			cookieNames: {
-				accessToken: 'accessToken-overridden',
-				accessTokenHash: 'accessTokenHash-overridden',
-				refreshToken: 'refreshToken-overridden',
-				refreshTokenExist: 'refreshTokenExist-overridden'
-			}
+				accessToken: "accessToken-overridden",
+				accessTokenHash: "accessTokenHash-overridden",
+				refreshToken: "refreshToken-overridden",
+				refreshTokenExist: "refreshTokenExist-overridden",
+			},
 		});
 
-		const result = cookieTokenSource['cookieNames']
+		const result = cookieTokenSource["cookieNames"];
 		expect(result).toStrictEqual({
-			accessToken: 'accessToken-overridden',
-			accessTokenHash: 'accessTokenHash-overridden',
-			refreshToken: 'refreshToken-overridden',
-			refreshTokenExist: 'refreshTokenExist-overridden'
+			accessToken: "accessToken-overridden",
+			accessTokenHash: "accessTokenHash-overridden",
+			refreshToken: "refreshToken-overridden",
+			refreshTokenExist: "refreshTokenExist-overridden",
 		});
 	});
 

--- a/src/tokensource/cookies.test.ts
+++ b/src/tokensource/cookies.test.ts
@@ -20,6 +20,45 @@ const createMockResponse = () => {
 };
 
 describe("CookieTokenSource", () => {
+
+	it("should use default cookie names", () => {
+		const cookieTokenSource = new CookieTokenSource({
+			secure: false,
+			sameSite: "strict",
+			refreshTokenPath: "/refresh",
+		});
+
+		const result = cookieTokenSource['cookieNames']
+		expect(result).toStrictEqual({
+			accessToken: "authToken",
+			accessTokenHash: "authTokenHash",
+			refreshToken: "authRefreshToken",
+			refreshTokenExist: "authRefreshTokenExist",
+		});
+	});
+
+	it("should override cookie names", () => {
+		const cookieTokenSource = new CookieTokenSource({
+			secure: false,
+			sameSite: "strict",
+			refreshTokenPath: "/refresh",
+			cookieNames: {
+				accessToken: 'accessToken-overridden',
+				accessTokenHash: 'accessTokenHash-overridden',
+				refreshToken: 'refreshToken-overridden',
+				refreshTokenExist: 'refreshTokenExist-overridden'
+			}
+		});
+
+		const result = cookieTokenSource['cookieNames']
+		expect(result).toStrictEqual({
+			accessToken: 'accessToken-overridden',
+			accessTokenHash: 'accessTokenHash-overridden',
+			refreshToken: 'refreshToken-overridden',
+			refreshTokenExist: 'refreshTokenExist-overridden'
+		});
+	});
+
 	it("should get the access token from cookies", () => {
 		const request = httpMocks.createRequest();
 		request.cookies = { authToken: "FOOBAR" };

--- a/src/tokensource/cookies.ts
+++ b/src/tokensource/cookies.ts
@@ -2,17 +2,17 @@ import { CookieOptions, Request, Response } from "express";
 import { TokenSource } from "./base";
 
 type CookieNames = {
-	accessToken: string
-	accessTokenHash: string
-	refreshToken: string
-	refreshTokenExist: string
-}
+	accessToken: string;
+	accessTokenHash: string;
+	refreshToken: string;
+	refreshTokenExist: string;
+};
 
 type CookieSourceOptions = {
 	secure: boolean;
 	sameSite: CookieOptions["sameSite"];
 	refreshTokenPath: string;
-	cookieNames?: CookieNames
+	cookieNames?: CookieNames;
 	publicDomainFn?: (request: Request) => string | undefined;
 	privateDomainFn?: (request: Request) => string | undefined;
 };

--- a/src/tokensource/cookies.ts
+++ b/src/tokensource/cookies.ts
@@ -1,15 +1,23 @@
 import { CookieOptions, Request, Response } from "express";
 import { TokenSource } from "./base";
 
+type CookieNames = {
+	accessToken: string
+	accessTokenHash: string
+	refreshToken: string
+	refreshTokenExist: string
+}
+
 type CookieSourceOptions = {
 	secure: boolean;
 	sameSite: CookieOptions["sameSite"];
 	refreshTokenPath: string;
+	cookieNames?: CookieNames
 	publicDomainFn?: (request: Request) => string | undefined;
 	privateDomainFn?: (request: Request) => string | undefined;
 };
 
-const DEFAULT_COOKIE_NAMES = {
+const DEFAULT_COOKIE_NAMES: CookieNames = {
 	accessToken: "authToken",
 	accessTokenHash: "authTokenHash",
 	refreshToken: "authRefreshToken",
@@ -35,7 +43,7 @@ export class CookieTokenSource implements TokenSource {
 
 	constructor(private options: CookieSourceOptions) {
 		this.cookieNames = {
-			...DEFAULT_COOKIE_NAMES,
+			...(options.cookieNames ?? DEFAULT_COOKIE_NAMES),
 		};
 
 		// If the secure option is set, we need to set the __Host- prefix for the


### PR DESCRIPTION
# Add cookienames option to CookieTokenSource constructor

Add option to override cookie names for CookieTokenSource. This solves the issue that all customers need to remove their cookies sometimes when something has changed on the cookie setup for example.