### PR TITLE
fix: removing cookies for specific paths and domains

### DIFF
--- a/.changeset/green-cameras-jam.md
+++ b/.changeset/green-cameras-jam.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/federated-token": patch
+---
+
+Fix removing cookies for specific paths and domains

--- a/src/tokensource/cookies.ts
+++ b/src/tokensource/cookies.ts
@@ -54,13 +54,22 @@ export class CookieTokenSource implements TokenSource {
 	}
 
 	deleteAccessToken(response: Response<any, Record<string, any>>): void {
-		response.clearCookie(this.cookieNames.accessToken);
-		response.clearCookie(this.cookieNames.accessTokenHash);
+		response.clearCookie(this.cookieNames.accessToken, {
+			domain: this.options?.publicDomainFn?.(response.req),
+		});
+		response.clearCookie(this.cookieNames.accessTokenHash, {
+			domain: this.options?.privateDomainFn?.(response.req),
+		});
 	}
 
 	deleteRefreshToken(response: Response<any, Record<string, any>>): void {
-		response.clearCookie(this.cookieNames.refreshToken);
-		response.clearCookie(this.cookieNames.refreshTokenExist);
+		response.clearCookie(this.cookieNames.refreshToken, {
+			path: this.options.refreshTokenPath,
+			domain: this.options?.privateDomainFn?.(response.req),
+		});
+		response.clearCookie(this.cookieNames.refreshTokenExist, {
+			domain: this.options?.publicDomainFn?.(response.req),
+		});
 	}
 
 	getAccessToken(request: Request): string {


### PR DESCRIPTION
# Fix for removing cookies for specific paths and domains

We need to specify `domain` option while removing cookies, if you also specified a `domain` option during creation. Same for `path` option (we use for refreshToken)