### PR TITLE
fix(react): use correct check for refresh token

### DIFF
--- a/.changeset/eight-timers-kick.md
+++ b/.changeset/eight-timers-kick.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/federated-token-react": patch
+---
+
+Fix error when refreshing access token

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -312,7 +312,7 @@ export function AuthProvider({
 		}
 
 		// Check if there is a GraphQL error
-		if (data.errors.length > 0) {
+		if (data.errors && data.errors.length > 0) {
 			throw new Error("Failed to refresh token");
 		}
 		return true;


### PR DESCRIPTION
The check for `data.errors` was invalid if the call was successful,
resulting in a javascript error
