### PR TITLE
fix: Removed check for existing refreshToken when setting accessToken

### DIFF
--- a/.changeset/many-geckos-whisper.md
+++ b/.changeset/many-geckos-whisper.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/federated-token-apollo": patch
+---
+
+Removed check for existing refreshToken when setting accessToken

--- a/packages/apollo/src/gateway.ts
+++ b/packages/apollo/src/gateway.ts
@@ -53,10 +53,7 @@ export class GatewayAuthPlugin<TContext extends PublicFederatedTokenContext>
 
 		const token = contextValue.federatedToken;
 
-		// Only load the access token if there is no refresh token. If a refresh
-		// token is present then we assume a refresh is happening and the
-		// accessToken is expired/invalid anyway
-		if (accessToken && !refreshToken) {
+		if (accessToken) {
 			try {
 				await token.loadAccessJWT(this.signer, accessToken, dataToken);
 			} catch (e: unknown) {


### PR DESCRIPTION
Removed a conditional check on refreshToken when checking if accessToken is set. This means that we will always set the accessToken if it exists, independent of whether a refreshToken is set