### PR TITLE
feat(react): allow passing a signal to refreshToken

### DIFF
--- a/.changeset/proud-olives-burn.md
+++ b/.changeset/proud-olives-burn.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/federated-token-react": minor
+---
+
+Allow passing a signal to the `refreshToken` call to for example set timeout using an AbortController


### PR DESCRIPTION
Allow passing a signal to the `refreshToken` call to for example set timeout using an AbortController
